### PR TITLE
prevent reassignment of non-local variables within function body scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,8 @@ func add -> int = [int a, int b] >> {
 
 ### Array Methods and Chaining
 ```
-let numbers = [1, 2, 3, 4, 5];
-let result = numbers
-    | map(x >> x * 2)
-    | filter(x >> x > 5)
-    | reduce((acc, x) >> acc + x, 0);
+int[] numbers = [1, 2, 3, 4, 5];
+int result = numbers >> map(double) >> reduce(add)
 ```
 
 ### Conditional Statements
@@ -126,8 +123,9 @@ The project is organised into several directories, each responsible for a differ
 ### Details
 - **src/**: Contains the source code.
   - **lexer/**: Lexer implementation.
-  - **parser/**: Parser implementation.
+  - **parser/**: Parser components.
   - **ast/**: AST nodes.
+  - **semantic/**: Semantic analyzer components.
 - **tests/**: Unit tests for each component.
 - **examples/**: Example programs written in the language.
 - **scripts/**: Helper scripts for building, testing, and running the project.

--- a/src/semantic/symbol.py
+++ b/src/semantic/symbol.py
@@ -1,5 +1,5 @@
 from typing import *
-from semantic.types import VarType
+from semantic.types import FunctionType, VarType
 
 class Symbol:
     """
@@ -27,13 +27,26 @@ class SymbolTable:
         """ Initializes the symbol table with an empty global scope. """
         self.scopes: List[Dict[str, Symbol]] = [{}]
 
+        self.function_types: List[FunctionType] = []
+        self.function_scopes: List[Dict[str, Symbol]] = [{}]
+
     def enter_scope(self) -> None:
         """ Enters a new scope by pushing a new dictionary onto the scope stack. """
         self.scopes.append({})
 
+    def enter_function_scope(self, fn_type: FunctionType) -> None:
+        self.enter_scope()
+
+        self.function_scopes.append(self.scopes[-1])
+        self.function_types.append(fn_type)
+
     def exit_scope(self) -> None:
         """ Exits the current scope by popping the dictionary off the scope stack. """
         self.scopes.pop()
+
+    def exit_function_scope(self) -> None:
+        self.exit_scope() # Also pops the function scope as the memory address is shared
+        self.function_types.pop()
 
     def define(self, name: str, var_type: VarType) -> None:
         """ Adds a symbol to the current scope.
@@ -62,3 +75,15 @@ class SymbolTable:
             if name in scope:
                 return scope[name]
         return None
+
+    def get_current_function_scope(self) -> Optional[Dict[str, Symbol]]:
+        if not self.function_scopes:
+            return None
+
+        return self.function_scopes[-1]
+
+    def get_current_function_type(self) -> Optional[FunctionType]:
+        if not self.function_types:
+            return None
+
+        return self.function_types[-1]

--- a/src/syntax/ast.py
+++ b/src/syntax/ast.py
@@ -232,7 +232,7 @@ class AssignmentExpression(Expression):
         return f'AssignmentExpression({self.left}, {self.right})'
 
 class IndexExpression(Expression):
-    def __init__(self, array: Expression, index: Expression) -> None:
+    def __init__(self, array: Identifier, index: Expression) -> None:
         self.array = array
         self.index = index
     def __repr__(self) -> str:

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -111,6 +111,30 @@ def test_function_declaration_and_call():
     """
     analyze_code(code)
 
+def test_function_variable_assignment_scope_error():
+    code = """
+        int x = 10;
+
+        func add -> void = [int a, int b] >> {
+            x = a + b;
+        }
+    """
+
+    with pytest.raises(NameError, match=r'Variable "x" not declared in the function scope'):
+        analyze_code(code)
+
+def test_function_index_assignment_scope_error():
+    code = """
+        int[] arr = [1, 2, 3];
+
+        func add -> void = [int[] a] >> {
+            arr[0] = a;
+        }
+    """
+
+    with pytest.raises(NameError, match=r'Variable "arr" not declared in the function scope'):
+        analyze_code(code)
+
 def test_nested_blocks_and_scopes():
     code = """
         int x = 5;


### PR DESCRIPTION
- adds logic to `SemanticAnalyzer` to prevent reassignment of non-local variables within function body scope
- extends symbol table to track function scopes and types
- fixes documentation