### PR TITLE
add halt and skip keywords

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -2,87 +2,115 @@
 
 ### Keywords
 ```ebnf
-KEYWORD = "let" | "return"
+KEYWORD = 'return' | 'if' | 'else' | 'while' | 'range' | 'each' | 'func' |
+          'echo' |'in' | 'to' | 'by' | 'halt' | 'skip' | 'int' | 'float' |
+          'bool' | 'string' | 'null' | 'infer' | 'void';
 ```
-
 
 ### Identifiers
 ```ebnf
-IDENTIFIER = LETTER , { LETTER | DIGIT | "_" };
-LETTER = "A" | "B" | ... | "Z" | "a" | "b" | ... | "z";
-DIGIT = "0" | "1" | ... | "9";
+IDENTIFIER = LETTER , { LETTER | DIGIT | '_' };
+LETTER = 'A' | 'B' | ... | 'Z' | 'a' | 'b' | ... | 'z';
+DIGIT = '0' | '1' | ... | '9';
 ```
-
 
 ### Primitive Types
 ```ebnf
 INT = DIGIT , { DIGIT };
-FLOAT = DIGIT , { DIGIT } , "." , DIGIT , { DIGIT };
+FLOAT = DIGIT , { DIGIT } , '.' , DIGIT , { DIGIT };
 NUMBER = INT | FLOAT;
-BOOL = "true" | "false";
+BOOL = 'true' | 'false';
 
-ASCII_CHAR = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 
-             'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 
-             'y' | 'z' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 
-             'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 
-             'W' | 'X' | 'Y' | 'Z' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | 
-             '8' | '9' | ' ' | '!' | '#' | '$' | '%' | '&' | '(' | ')' | '*' | '+' | 
-             ',' | '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '[' | 
-             '\\' | ']' | '^' | '_' | '`' | '{' | '|' | '}' | '~' | '\'' | '\"';
-ESCAPE_CHAR = '\\' , ( '\'' | '\"' | '\\' );
+ASCII_CHAR = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' |
+             'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' |
+             'y' | 'z' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' |
+             'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' |
+             'W' | 'X' | 'Y' | 'Z' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' |
+             '8' | '9' | ' ' | '!' | '#' | '$' | '%' | '&' | '(' | ')' | '*' | '+' |
+             ',' | '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '[' |
+             '\\' | ']' | '^' | '_' | '`' | '{' | '|' | '}' | '~' | '\'' | '"';
+ESCAPE_CHAR = '\\' , ( '\'' | '"' | '\\' );
 STRING = { ASCII_CHAR | ESCAPE_CHAR };
 ```
 
 ### Operators
 ```ebnf
-OPERATORS = 
-    | LOGICAL_OPERATORS 
-    | MATHEMATICAL_OPERATORS 
-    | RELATIONAL_OPERATORS 
-    | ASSIGNMENT_OPERATORS 
+OPERATORS =
+    | LOGICAL_OPERATORS
+    | MATHEMATICAL_OPERATORS
+    | RELATIONAL_OPERATORS
+    | ASSIGNMENT_OPERATORS
     | INCREMENT_DECREMENT_OPERATORS;
 
-LOGICAL_OPERATORS = "&&" | "||" | "!";
-MATHEMATICAL_OPERATORS = "+" | "-" | "*" | "/";
-RELATIONAL_OPERATORS = "==" | "!=" | "<" | ">" | "<=" | ">=" ;
-ASSIGNMENT_OPERATORS = "=" | "+=" | "-=" | "*=" | "/=";
-INCREMENT_DECREMENT_OPERATORS = "++" | "--";
+LOGICAL_OPERATORS = '&&' | '||' | '!';
+MATHEMATICAL_OPERATORS = '+' | '-' | '*' | '/';
+RELATIONAL_OPERATORS = '==' | '!=' | '<' | '>' | '<=' | '>=' ;
+ASSIGNMENT_OPERATORS = '=' | '+=' | '-=' | '*=' | '/=';
+INCREMENT_DECREMENT_OPERATORS = '++' | '--';
 ```
 
 ### Expressions
 ```ebnf
-EXPRESSION = 
-    | ASSIGNMENT_EXPRESSION 
-    | FUNC_DEFINITION 
+EXPRESSION =
+    | ASSIGNMENT_EXPRESSION
+    | FUNC_DEFINITION
     | ARITHMETIC_EXPRESSION
-    | COMPARISION_EXPRESSION;
+    | COMPARISON_EXPRESSION
+    | LOGICAL_EXPRESSION
+    | UNARY_EXPRESSION
+    | CALL_EXPRESSION
+    | PIPE_EXPRESSION
+    | LITERAL;
 
-ASSIGNMENT_EXPRESSION = "let" , IDENTIFIER , "=" , EXPRESSION , ";";
+ASSIGNMENT_EXPRESSION = IDENTIFIER , ASSIGNMENT_OPERATORS , EXPRESSION , ';';
+FUNC_DEFINITION = 'func' , IDENTIFIER , '->' , TYPE , '=' , '[' , [ PARAM_LIST ] , ']' , '>>' , '{' , { STATEMENT } , '}';
+PARAM_LIST = PARAM , { ',' , PARAM };
+PARAM = TYPE , IDENTIFIER;
+TYPE = 'int' | 'float' | 'string' | 'bool' | 'void' | IDENTIFIER;
 
-FUNC_DEFINITION = "(" , [ PARAM_LIST ] , ")" , "->" , TYPE , "=>" , "{" , { STATEMENT } , "}";
-PARAM_LIST = PARAM , { "," , PARAM };
-PARAM = IDENTIFIER , ":" , TYPE;
-TYPE = "int" | "float" | "string" | "bool" | IDENTIFIER;
+ARITHMETIC_EXPRESSION = TERM , { ('+' | '-') , TERM };
+TERM = FACTOR , { ('*' | '/') , FACTOR };
+FACTOR = NUMBER | IDENTIFIER | '(' , EXPRESSION , ')';
+COMPARISON_EXPRESSION = EXPRESSION , RELATIONAL_OPERATORS , EXPRESSION;
+LOGICAL_EXPRESSION = EXPRESSION , LOGICAL_OPERATORS , EXPRESSION;
+UNARY_EXPRESSION = INCREMENT_DECREMENT_OPERATORS , IDENTIFIER | '!' , IDENTIFIER;
+CALL_EXPRESSION = IDENTIFIER , '(' , [ ARG_LIST ] , ')';
+ARG_LIST = EXPRESSION , { ',' , EXPRESSION };
+PIPE_EXPRESSION =  '[' , ARG_LIST , ']' , '>>' , PIPE_FUNCTION , { '>>' , PIPE_FUNCTION };
+PIPE_FUNCTION = IDENTIFIER , [ '(' , [ FUNC_ARG_LIST ] , ')' ];
 
-ARITHMETIC_EXPRESSION = TERM , { ("+" | "-") , TERM };
-TERM = FACTOR , { ("*" | "/") , FACTOR };
-FACTOR = INT | FLOAT | IDENTIFIER | "(" , EXPRESSION , ")";
-COMPARISION_EXPRESSION = EXPRESSION , ( ">" | "<" | "==" | "!=" ) , EXPRESSION;
+LITERAL = NUMBER | STRING | BOOL | 'null';
 ```
 
 ### Statements
 ```ebnf
-STATEMENT = 
-    | ASSIGNMENT_STATEMENT 
-    | RETURN_STATEMENT 
-    | CONDITIONAL_STATEMENT 
+STATEMENT =
+    | VARIABLE_DECLARATION
+    | RETURN_STATEMENT
+    | CONDITIONAL_STATEMENT
     | LOOP_STATEMENT
-    | FUNC_CALL_STATEMENT;
+    | EACH_STATEMENT
+    | RANGE_STATEMENT
+    | HALT_STATEMENT
+    | SKIP_STATEMENT
+    | ECHO_STATEMENT
+    | EXPRESSION_STATEMENT
+    | BLOCK_STATEMENT;
 
-ASSIGNMENT_STATEMENT = ASSIGNMENT_EXPRESSION;
-RETURN_STATEMENT = "return" , EXPRESSION , ";";
-CONDITIONAL_STATEMENT = "if", EXPRESSION , "{" , { STATEMENT } , "}" , [ "else" , "{" , { STATEMENT } , "}" ];
-LOOP_STATEMENT = "while" , EXPRESSION , {" , { STATEMENT } , "}";
-FUNC_CALL_STATEMENT = IDENTIFIER , "(" , [ ARG_LIST ] , ")" , ";";
-ARG_LIST = EXPRESSION , { "," , EXPRESSION };
+VARIABLE_DECLARATION = TYPE , IDENTIFIER , '=' , EXPRESSION , ';';
+RETURN_STATEMENT = 'return' , EXPRESSION , ';';
+CONDITIONAL_STATEMENT = 'if' , EXPRESSION , '{' , { STATEMENT } , '}' , [ 'else' , '{' , { STATEMENT } , '}' ];
+LOOP_STATEMENT = 'while' , '(' , EXPRESSION , ')' , '{' , { STATEMENT } , '}';
+EACH_STATEMENT = 'each' , IDENTIFIER , 'in' , EXPRESSION , '{' , { STATEMENT } , '}';
+RANGE_STATEMENT = 'range' , IDENTIFIER , 'in' , EXPRESSION , 'to' , EXPRESSION , [ 'by' , EXPRESSION ] , '{' , { STATEMENT } , '}';
+HALT_STATEMENT = 'halt' , ';';
+SKIP_STATEMENT = 'skip' , ';';
+ECHO_STATEMENT = 'echo' , STRING , ';';
+EXPRESSION_STATEMENT = EXPRESSION , ';';
+BLOCK_STATEMENT = '{' , { STATEMENT } , '}';
+```
+
+### Program
+```ebnf
+PROGRAM = { STATEMENT };
 ```

--- a/src/lexer/lexer.py
+++ b/src/lexer/lexer.py
@@ -59,7 +59,7 @@ class Lexer:
                 case TokenType.NEWLINE:
                     self.line += 1
                     self.column = 1
-                case TokenType.SKIP:
+                case TokenType.GAP:
                     self.column += len(value)  # Skip whitespace
                 case TokenType.EOL_COMMENT:
                     self.line += 1

--- a/src/lexer/tokens.py
+++ b/src/lexer/tokens.py
@@ -13,6 +13,8 @@ class TokenType(Enum):
     IN = auto()                 # "in"
     TO = auto()                 # "to"
     BY = auto()                 # "by"
+    HALT = auto()               # "halt"
+    SKIP = auto()               # "skip"
 
     INT = auto()                # "int"
     FLOAT = auto()              # "float"
@@ -87,7 +89,7 @@ class TokenType(Enum):
     EOF = auto()
 
     # Other
-    SKIP = auto()
+    GAP = auto()
     NEWLINE = auto()
     MISMATCH = auto()
 '''
@@ -108,6 +110,8 @@ spec = (
     (TokenType.IN, r'\bin\b'),
     (TokenType.TO, r'\bto\b'),
     (TokenType.BY, r'\bby\b'),
+    (TokenType.HALT, r'\bhalt\b'),
+    (TokenType.SKIP, r'\bskip\b'),
 
     (TokenType.INT, r'\bint\b'),
     (TokenType.FLOAT, r'\bfloat\b'),
@@ -137,18 +141,18 @@ spec = (
     (TokenType.INCREMENT, r'\+\+'),
     (TokenType.DECREMENT, r'--'),
 
-    (TokenType.ASSIGN, r'='),
-    (TokenType.PLUS_ASSIGN, r'\+='),
-    (TokenType.MINUS_ASSIGN, r'-='),
-    (TokenType.MULTIPLY_ASSIGN, r'\*='),
-    (TokenType.DIVIDE_ASSIGN, r'/='),
-
     (TokenType.EQUAL, r'=='),
     (TokenType.NOT_EQUAL, r'!='),
     (TokenType.LTE, r'<='),
     (TokenType.GTE, r'>='),
     (TokenType.LT, r'<'),
     (TokenType.GT, r'>'),
+
+    (TokenType.ASSIGN, r'='),
+    (TokenType.PLUS_ASSIGN, r'\+='),
+    (TokenType.MINUS_ASSIGN, r'-='),
+    (TokenType.MULTIPLY_ASSIGN, r'\*='),
+    (TokenType.DIVIDE_ASSIGN, r'/='),
 
     (TokenType.PLUS, r'\+'),
     (TokenType.MINUS, r'-'),
@@ -165,7 +169,7 @@ spec = (
 
     (TokenType.IDENTIFIER, r'[A-Za-z_]\w*'),
 
-    (TokenType.SKIP, r'[ \t]+'),
+    (TokenType.GAP, r'[ \t]+'),
     (TokenType.NEWLINE, r'\n'),
     (TokenType.MISMATCH, r'.')
 )

--- a/src/parser/statements.py
+++ b/src/parser/statements.py
@@ -4,9 +4,8 @@ from parser.types import ParserABC, StatementParserABC
 from parser.expressions import ExpressionParser
 from semantic.types import ArrayType, FunctionType, InferType, PrimitiveType, VarType, VoidType
 from syntax.ast import (
-    EchoStatement, Statement, ExpressionStatement, VariableDeclaration, BlockStatement, IfStatement,
-    WhileStatement, RangeStatement, EachStatement, ReturnStatement, FunctionDeclaration,
-    NumericLiteral
+    EchoStatement, HaltStatement, SkipStatement, Statement, ExpressionStatement, VariableDeclaration, BlockStatement,
+    IfStatement, WhileStatement, RangeStatement, EachStatement, ReturnStatement, FunctionDeclaration, NumericLiteral
 )
 
 class StatementParser(StatementParserABC):
@@ -59,10 +58,14 @@ class StatementParser(StatementParserABC):
                 return self.parse_range_statement()
             case TokenType.EACH:
                 return self.parse_each_statement()
-            case TokenType.RETURN:
-                return self.parse_return_statement()
+            case TokenType.HALT:
+                return self.parse_halt_statement()
+            case TokenType.SKIP:
+                return self.parse_skip_statement()
             case TokenType.FUNC:
                 return self.parse_function_declaration()
+            case TokenType.RETURN:
+                return self.parse_return_statement()
             case TokenType.ECHO:
                 return self.parse_echo_statement()
             case _:
@@ -177,6 +180,28 @@ class StatementParser(StatementParserABC):
         body = self.parse_block_statement()
 
         return EachStatement(identifier.value, iterable, body)
+
+    def parse_halt_statement(self) -> HaltStatement:
+        """ Parses a halt statement.
+
+        Returns:
+            HaltStatement: The parsed halt statement.
+        """
+        self.parser.consume(TokenType.HALT)
+        self.parser.consume(TokenType.SEMICOLON)
+
+        return HaltStatement()
+
+    def parse_skip_statement(self) -> SkipStatement:
+        """ Parses a skip statement.
+
+        Returns:
+            SkipStatement: The parsed skip statement.
+        """
+        self.parser.consume(TokenType.SKIP)
+        self.parser.consume(TokenType.SEMICOLON)
+
+        return SkipStatement()
 
     def parse_return_statement(self) -> ReturnStatement:
         """ Parses a return statement.

--- a/src/syntax/ast.py
+++ b/src/syntax/ast.py
@@ -14,13 +14,15 @@ class Program(Statement):
         return f'Program({self.body})'
 
 # Statements
-"""
-1. Variable Declaration Statement
-   Syntax: let <variable_name> = <initializer>;
-
-    let x = 5;
-"""
 class VariableDeclaration(Statement):
+    """ Node representing a variable declaration statement.
+
+    Syntax:
+        let <variable_name> = <initializer>;
+
+    Example:
+        let x = 5;
+    """
     def __init__(self, name: str, var_type: VarType, initializer: Node) -> None:
         self.name = name
         self.var_type = var_type
@@ -28,45 +30,62 @@ class VariableDeclaration(Statement):
     def __repr__(self) -> str:
         return f'VariableDeclaration({self.name}, {self.var_type}, {self.initializer})'
 
-"""
-2.  Expression Statement
-    Syntax: <expression>;
-
-    5 + 5;
-"""
 class ExpressionStatement(Statement):
+    """ Node representing an expression statement.
+
+    Args:
+        expression (Node): The expression to be evaluated.
+
+    Syntax:
+        <expression>;
+
+    Example:
+        5 + 5;
+    """
     def __init__(self, expression: Node) -> None:
         self.expression = expression
     def __repr__(self) -> str:
         return f'ExpressionStatement({self.expression})'
 
-"""
-3.  Block Statement
-    Syntax: { <statements> }
-
-    {
-        let x = 5;
-        let y = 10;
-    }
-"""
 class BlockStatement(Statement):
+    """ Node representing a block statement.
+
+    Args:
+        statements (List[Statement]): The statements within the block.
+
+    Syntax:
+        { <statements> }
+
+    Example:
+        {
+            let x = 5;
+            let y = 10;
+        }
+    """
     def __init__(self, statements: List[Statement]) -> None:
         self.statements = statements
 
     def __repr__(self) -> str:
         return f'BlockStatement({self.statements})'
 
-"""
-4. If Statement
-    Syntax: if <condition> <then_branch> else <else_branch>
-
-    if x > 5 {
-        return x;
-    } else {
-        return 5;
-    }
-"""
 class IfStatement(Statement):
+    """ Node representing an if statement.
+
+    Args:
+        condition (Expression): The condition to be evaluated.
+        then_block (BlockStatement): The block to be executed if the condition is true.
+        else_block (Optional[BlockStatement]): The block to be executed if the condition is false.
+
+    Syntax:
+        if <condition> <then_block> else <else_block>
+
+    Example:
+        if x > 5 {
+            return x;
+        } else {
+            return 5;
+        }
+    """
     def __init__(self, condition: Expression, then_block: BlockStatement, else_block: Optional[BlockStatement]) -> None:
         self.condition = condition
         self.then_block = then_block
@@ -75,15 +94,22 @@ class IfStatement(Statement):
     def __repr__(self) -> str:
         return f'IfStatement({self.condition}, {self.then_block}, {self.else_block})'
 
-"""
-5. While Statement
-    Syntax: while <condition> <body>
-
-    while x < 5 {
-        x = x + 1;
-    }
-"""
 class WhileStatement(Statement):
+    """ Node representing a while statement.
+
+    Args:
+        condition (Expression): The condition to be evaluated.
+        body (BlockStatement): The block to be executed while the condition is true.
+
+    Syntax:
+        while <condition> <body>
+
+    Example:
+        while x < 5 {
+            x = x + 1;
+        }
+    """
+
     def __init__(self, condition: Expression, body: BlockStatement) -> None:
         self.condition = condition
         self.body = body
@@ -91,15 +117,24 @@ class WhileStatement(Statement):
     def __repr__(self) -> str:
         return f'WhileStatement({self.condition}, {self.body})'
 
-"""
-6.  Range Statement
-    Syntax: range <identifier> in <start> to <end> by <increment> <body>
-
-    range i in 0 to 10 by 1 {
-        echo i;
-    }
-"""
 class RangeStatement(Statement):
+    """ Node representing a range statement.
+
+    Args:
+        identifier (str): The identifier to be used in the range.
+        start (Expression): The starting value of the range.
+        end (Expression): The ending value of the range.
+        increment (Expression): The increment value of the range.
+        body (BlockStatement): The block to be executed for each value in the range.
+
+    Syntax:
+        range <identifier> in <start> to <end> by <increment> <body>
+
+    Example:
+        range i in 0 to 10 by 1 {
+            echo i;
+        }
+    """
     def __init__(self, identifier: str, start: Expression, end: Expression, increment: Expression, body: BlockStatement) -> None:
         self.identifier = identifier
         self.start = start
@@ -110,16 +145,22 @@ class RangeStatement(Statement):
     def __repr__(self) -> str:
         return f'RangeStatement({self.identifier}, {self.start}, {self.end}, {self.increment}, {self.body})'
 
-
-"""
-7.  Each Statement
-    Syntax: each <variable> in <iterable> <body>
-
-    each item in items {
-        echo item;
-    }
-"""
 class EachStatement(Statement):
+    """ Node representing an each statement.
+
+    Args:
+        variable (str): The variable to be used in the each statement.
+        iterable (Expression): The iterable to be looped over.
+        body (BlockStatement): The block to be executed for each value in the iterable.
+
+    Syntax:
+        each <variable> in <iterable> <body>
+
+    Example:
+        each item in items {
+            echo item;
+        }
+    """
     def __init__(self, variable: str, iterable: Expression, body: BlockStatement) -> None:
         self.variable = variable
         self.iterable = iterable
@@ -128,28 +169,51 @@ class EachStatement(Statement):
     def __repr__(self) -> str:
         return f'EachStatement({self.variable}, {self.iterable}, {self.body})'
 
-"""
-8.  Return Statement
-    Syntax: return <expression>;
+class HaltStatement(Statement):
+    """ Node representing a halt statement.
 
-    return 5;
-"""
-class ReturnStatement(Statement):
-    def __init__(self, expression: Optional[Expression]) -> None:
-        self.expression = expression
+    Syntax:
+        halt;
+
+    Example:
+        halt;
+    """
+    def __init__(self) -> None:
+        pass
 
     def __repr__(self) -> str:
-        return f'ReturnStatement({self.expression})'
+        return 'HaltStatement()'
 
-"""
-9.  Function Declaration
-    Syntax: func <name> = [<parameters>] >> <body>
+class SkipStatement(Statement):
+    """ Node representing a skip statement.
 
-    func add = [x, y] >> {
-        return x + y;
-    }
-"""
+    Syntax:
+        skip;
+
+    Example:
+        skip;
+    """
+    def __init__(self) -> None:
+        pass
+    def __repr__(self) -> str:
+        return 'SkipStatement()'
+
 class FunctionDeclaration(Statement):
+    """ Node representing a function declaration.
+
+    Args:
+        name (str): The name of the function.
+        function_type (FunctionType): The type of the function.
+        body (BlockStatement): The block to be executed when the function is called.
+
+    Syntax:
+        func <name> -> <return type> = [<parameters>] >> <body>
+
+    Example:
+        func add -> int = [int x, int y] >> {
+            return x + y;
+        }
+    """
     def __init__(self, name: str, function_type: FunctionType, body: BlockStatement) -> None:
         self.name = name
         self.function_type = function_type
@@ -158,13 +222,36 @@ class FunctionDeclaration(Statement):
     def __repr__(self) -> str:
         return f'FunctionDeclaration({self.name}, {self.function_type}, {self.body})'
 
-"""
-10. Echo Statement
-    Syntax: echo <expression>;
+class ReturnStatement(Statement):
+    """ Node representing a return statement.
 
-    echo "Hello, World!";
-"""
+    Args:
+        expression (Optional[Expression]): The expression to be returned.
+
+    Syntax:
+        return <expression>;
+
+    Example:
+        return 5;
+    """
+    def __init__(self, expression: Optional[Expression]) -> None:
+        self.expression = expression
+
+    def __repr__(self) -> str:
+        return f'ReturnStatement({self.expression})'
+
 class EchoStatement(Statement):
+    """ Node representing an echo statement.
+
+    Args:
+        expression (Expression): The expression to be echoed.
+
+    Syntax:
+        echo <expression>;
+
+    Example:
+        echo "Hello, World!";
+    """
     def __init__(self, expression: Expression) -> None:
         self.expression = expression
 
@@ -173,42 +260,75 @@ class EchoStatement(Statement):
 
 # Expressions
 class NumericLiteral(Expression):
+    """ Node representing a numeric literal.
+
+    Args:
+        value (Union[int, float]): The value of the numeric literal.
+    """
     def __init__(self, value: Union[int, float]) -> None:
         self.value = value
     def __repr__(self) -> str:
         return f'NumericLiteral({self.value})'
 
 class StringLiteral(Expression):
+    """ Node representing a string literal.
+
+    Args:
+        value (str): The value of the string literal.
+    """
     def __init__(self, value: str) -> None:
         self.value = value
     def __repr__(self) -> str:
         return f'StringLiteral({self.value})'
 
 class BooleanLiteral(Expression):
+    """ Node representing a boolean literal.
+
+    Args:
+        value (bool): The value of the boolean literal.
+    """
     def __init__(self, value: bool) -> None:
         self.value = value
     def __repr__(self) -> str:
         return f'BooleanLiteral({self.value})'
 
 class NullLiteral(Expression):
+    """ Node representing a null literal. """
     def __init__(self) -> None:
         self.value = None
     def __repr__(self) -> str:
         return f'NullLiteral()'
 
 class ArrayLiteral(Expression):
+    """ Node representing an array literal.
+
+    Args:
+        elements (List[Expression]): The elements of the array.
+    """
     def __init__(self, elements: List[Expression]) -> None:
         self.elements = elements
     def __repr__(self) -> str:
         return f'ArrayLiteral({self.elements})'
 
 class Identifier(Expression):
+    """ Node representing an identifier.
+
+    Args:
+        name (str): The name of the identifier.
+    """
     def __init__(self, name: str) -> None:
         self.name = name
     def __repr__(self) -> str:
         return f'Identifier({self.name})'
 
 class UnaryExpression(Expression):
+    """ Node representing a unary expression.
+
+    Args:
+        operator (TokenType): The operator of the unary expression.
+        operand (Expression): The operand of the unary expression.
+        position (Literal['PRE', 'POST']): The position of the operator.
+    """
     def __init__(self, operator: TokenType, operand: Expression, position: Literal['PRE', 'POST']) -> None:
         self.operator = operator
         self.operand = operand
@@ -217,6 +337,13 @@ class UnaryExpression(Expression):
         return f'UnaryExpression({self.operator}, {self.operand}, {self.position})'
 
 class BinaryExpression(Expression):
+    """ Node representing a binary expression.
+
+    Args:
+        left (Expression): The left operand of the binary expression.
+        operator (TokenType): The operator of the binary expression.
+        right (Expression): The right operand of the binary expression.
+    """
     def __init__(self, left: Node, operator: TokenType, right: Node) -> None:
         self.left = left
         self.operator = operator
@@ -225,6 +352,12 @@ class BinaryExpression(Expression):
         return f'BinaryExpression({self.left}, {self.operator}, {self.right})'
 
 class AssignmentExpression(Expression):
+    """ Node representing an assignment expression.
+
+    Args:
+        left (Node): The left operand of the assignment expression.
+        right (Node): The right operand of the assignment expression.
+    """
     def __init__(self, left: Node, right: Node) -> None:
         self.left = left
         self.right = right
@@ -232,6 +365,12 @@ class AssignmentExpression(Expression):
         return f'AssignmentExpression({self.left}, {self.right})'
 
 class IndexExpression(Expression):
+    """ Node representing an index expression.
+
+    Args:
+        array (Expression): The array to be indexed.
+        index (Expression): The index of the array.
+    """
     def __init__(self, array: Expression, index: Expression) -> None:
         self.array = array
         self.index = index
@@ -239,6 +378,12 @@ class IndexExpression(Expression):
         return f'IndexExpression({self.array}, {self.index})'
 
 class CallExpression(Expression):
+    """ Node representing a call expression.
+
+    Args:
+        callee (Identifier): The function to be called.
+        args (List[Expression]): The arguments to be passed to the function.
+    """
     def __init__(self, callee: Identifier, args: List[Expression]) -> None:
         self.callee = callee
         self.args = args

--- a/tests/semantic/test_scope.py
+++ b/tests/semantic/test_scope.py
@@ -139,6 +139,29 @@ def test_range_statement():
     """
     analyze_code(code)
 
+def test_halt_statement():
+    code = """
+        int x = 0;
+        while x < 10 {
+            x++;
+            if x == 5 {
+                halt; // skip the current iteration
+            }
+            echo x;
+        }
+    """
+    analyze_code(code)
+
+def test_invalid_skip_statement():
+    code = """
+        if true {
+            skip; // halt statement is only allowed in loop scopes
+        }
+    """
+
+    with pytest.raises(SyntaxError, match=r'Skip statement is not valid outside of a loop block'):
+        analyze_code(code)
+
 def test_block_scope():
     code = """
         int x = 10;

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -91,24 +91,6 @@ def test_nested_if_else():
     ])
     check(code, expected)
 
-def test_while_statement():
-    code = """
-        while (x < 10) {
-            x++;
-        }
-    """
-    expected = Program([
-        WhileStatement(
-            BinaryExpression(Identifier("x"), TokenType.LT, NumericLiteral(10)),
-            BlockStatement([
-                ExpressionStatement(
-                    UnaryExpression(TokenType.INCREMENT, Identifier("x"), 'POST')
-                )
-            ])
-        )
-    ])
-    check(code, expected)
-
 def test_unary_expressions():
     code = """
         x++;
@@ -214,6 +196,24 @@ def test_combined_array_example():
     ])
     check(code, expected)
 
+def test_while_statement():
+    code = """
+        while (x < 10) {
+            x++;
+        }
+    """
+    expected = Program([
+        WhileStatement(
+            BinaryExpression(Identifier("x"), TokenType.LT, NumericLiteral(10)),
+            BlockStatement([
+                ExpressionStatement(
+                    UnaryExpression(TokenType.INCREMENT, Identifier("x"), 'POST')
+                )
+            ])
+        )
+    ])
+    check(code, expected)
+
 def test_each_statement():
     code = """
         each x in [1, 2, 3] {
@@ -243,6 +243,55 @@ def test_range_statement():
             NumericLiteral(10),
             NumericLiteral(1),
             BlockStatement([ReturnStatement(Identifier("x"))])
+        )
+    ])
+    check(code, expected)
+
+def test_halt_statement():
+    code = """
+        range x in 0 to 10 {
+            if x == 5 {
+                halt;
+            }
+        }
+    """
+    expected = Program([
+        RangeStatement(
+            "x",
+            NumericLiteral(0),
+            NumericLiteral(10),
+            NumericLiteral(1),
+            BlockStatement([
+                IfStatement(
+                    BinaryExpression(Identifier("x"), TokenType.EQUAL, NumericLiteral(5)),
+                    BlockStatement([HaltStatement()]),
+                    None
+                )
+            ])
+        )
+    ])
+    check(code, expected)
+
+def test_skip_statement():
+    code = """
+        each x in [1, 2, 3, 4] {
+            if isEven(x) {
+                skip;
+            }
+        }
+    """
+
+    expected = Program([
+        EachStatement(
+            "x",
+            ArrayLiteral([NumericLiteral(1), NumericLiteral(2), NumericLiteral(3), NumericLiteral(4)]),
+            BlockStatement([
+                IfStatement(
+                    CallExpression(Identifier("isEven"), [Identifier("x")]),
+                    BlockStatement([SkipStatement()]),
+                    None
+                )
+            ])
         )
     ])
     check(code, expected)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -91,7 +91,7 @@ def test_incomplete_block_statement():
     check(code)
 
 def test_invalid_assignment():
-    code = "x == 10;"
+    code = "int x == 10;"
     check(code)
 
 def test_double_variable_declaration():


### PR DESCRIPTION
- adds `halt` and `skip` keywords for loop control flow
  - adds relevant tests for both parser and semantic analyser
  - changes behaviour of `SemanticAnalyzer.analyze_block_statement` to optionally not create a new scope
  - changes parameters of `SymbolTable.enter_scope` to take a parent node instead of a function type
  - adds `SymbolTable.is_loop_scope` to check if current scope is within a loop
- fixes parsing of `==` token
- adds docstrings to all AST node classes
- updates `grammar.md` to reflect current syntax