### PR TITLE
add reachability checking to semantic analyzer

### DIFF
--- a/src/parser/statements.py
+++ b/src/parser/statements.py
@@ -210,7 +210,7 @@ class StatementParser(StatementParserABC):
             ReturnStatement: The parsed return statement.
         """
         self.parser.consume(TokenType.RETURN)
-        expr = self.expression_parser.parse_expression()
+        expr = None if self.parser.current().type == TokenType.SEMICOLON else self.expression_parser.parse_expression()
         self.parser.consume(TokenType.SEMICOLON)
 
         return ReturnStatement(expr)

--- a/src/semantic/symbol.py
+++ b/src/semantic/symbol.py
@@ -28,6 +28,7 @@ class Scope:
     def __init__(self, parent_node: Optional[Statement] = None) -> None:
         self.symbols: Dict[str, Symbol] = {}
         self.parent_node = parent_node
+        self.reachable = True
 
     def __repr__(self) -> str:
         return f'Scope(parent_node={self.parent_node}, symbols={list(self.symbols.keys())})'
@@ -130,3 +131,22 @@ class SymbolTable:
                 return True
 
         return False
+
+    def is_reachable(self) -> bool:
+        """ Checks if the current scope is reachable.
+
+        Returns:
+            bool: True if the current scope is reachable, otherwise False.
+        """
+
+        for scope in reversed(self.scopes):
+            if not scope.reachable:
+                return False
+
+        return True
+
+    def set_unreachable(self) -> None:
+        """ Marks the current scope as unreachable.
+        """
+
+        self.scopes[-1].reachable = False

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -83,7 +83,7 @@ def test_invalid_pipe_expression():
     check(code)
 
 def test_invalid_return_statement():
-    code = "return;"
+    code = "return"
     check(code)
 
 def test_incomplete_block_statement():


### PR DESCRIPTION
- adds reachability analysis to semantic analyzer
  - adds `reachable` attribute to `Scope` class and `is_reachable` method to `SymbolTable`
  - checks for code after `return`, `halt`, and `skip` statements
  - checks reachability of code in if-else blocks with boolean literal conditions
  - adds relevant tests
- adds error details to semantic analyzer method docstrings
- fixes void return statements