### PR TITLE
add templates and entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python setup.py
 ### Variable Declarations
 ```
 int x = 10;
-string y = 'Hello, World!';
+str y = 'Hello, World!';
 bool z = true;
 ```
 
@@ -67,6 +67,30 @@ func add -> int = [int a, int b] >> {
 }
 ```
 
+### Templates and Entities
+```
+template User {
+    str name;
+    int age;
+    User[] followers;
+
+    func poke -> void = [] >> {
+        echo 'Poked ' + name;
+    } 
+}
+
+entity user = User{
+    name: 'James',
+    age: 25,
+    followers: [
+        User{name: 'Alice', age: 30, followers: []},
+        User{name: 'Bob', age: 28, followers: []}
+    ]
+};
+
+user.poke();
+```
+
 ### Array Methods and Chaining
 ```
 int[] numbers = [1, 2, 3, 4, 5];
@@ -75,7 +99,7 @@ int result = numbers >> map(double) >> reduce(add)
 
 ### Conditional Statements
 ```
-if x > 10 {
+if (x > 10) {
     echo 'Greater than 10';
 } else {
     echo 'Less than or equal to 10';
@@ -85,17 +109,17 @@ if x > 10 {
 ### Loops
 ```
 // Each loop
-each element in numbers {
+each (element in numbers) {
     echo element;
 }
 
 // Range loop
-range i in 0 to 10 {
+range (i in 0 to 10) {
     echo i;
 }
 
 // While loop
-while x < 10 {
+while (x < 10) {
     x++;
 }
 ```

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -4,7 +4,9 @@
 ```ebnf
 KEYWORD = 'return' | 'if' | 'else' | 'while' | 'range' | 'each' | 'func' |
           'echo' |'in' | 'to' | 'by' | 'halt' | 'skip' | 'int' | 'float' |
-          'bool' | 'string' | 'null' | 'infer' | 'void';
+          'bool' | 'string' | 'null' | 'infer' | 'void' | 'true' | 'false' |
+          'template' | 'entity' 
+
 ```
 
 ### Identifiers
@@ -30,7 +32,7 @@ ASCII_CHAR = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | '
              ',' | '-' | '.' | '/' | ':' | ';' | '<' | '=' | '>' | '?' | '@' | '[' |
              '\\' | ']' | '^' | '_' | '`' | '{' | '|' | '}' | '~' | '\'' | '"';
 ESCAPE_CHAR = '\\' , ( '\'' | '"' | '\\' );
-STRING = { ASCII_CHAR | ESCAPE_CHAR };
+STR = { ASCII_CHAR | ESCAPE_CHAR };
 ```
 
 ### Collection Types
@@ -38,6 +40,14 @@ STRING = { ASCII_CHAR | ESCAPE_CHAR };
 ARRAY = '[' , [ EXPRESSION , { ',' , EXPRESSION } ] , ']';
 SET = '{' , [ EXPRESSION , { ',' , EXPRESSION } ] , '}';
 MAP = '{' , [ EXPRESSION , ':' , EXPRESSION , { ',' , EXPRESSION , ':' , EXPRESSION } ] , '}';
+```
+
+### Object Types
+```ebnf
+TEMPLATE_DECLARATION = 'template' , IDENTIFIER , '{' , { ATTRIBUTE_DECLARATION, FUNCTION_DECLARATION } , '}';
+ENTITY = 'entity' , IDENTIFIER, =, ENTITY_LITERAL;
+ATTRIBUTE_DECLARATION = TYPE , IDENTIFIER , ';';
+ENTITY_LITERAL = IDENTIFIER, '{' , { IDENTIFIER , ':' , EXPRESSION , ',' } , '}';
 ```
 
 ### Operators
@@ -88,12 +98,13 @@ COMPARISON_EXPRESSION = EXPRESSION , RELATIONAL_OPERATORS , EXPRESSION;
 LOGICAL_EXPRESSION = EXPRESSION , LOGICAL_OPERATORS , EXPRESSION;
 UNARY_EXPRESSION = INCREMENT_DECREMENT_OPERATORS , IDENTIFIER | '!' , IDENTIFIER;
 FUNCTION_CALL_EXPRESSION = IDENTIFIER , '(' , [ ARG_LIST ] , ')';
+ANONYMOUS_FUNCTION = 'func', '[', [ PARAM_LIST ], ']', '>>', '{', { STATEMENT }, '}';
 METHOD_CALL_EXPRESSION = IDENTIFIER , '.' , IDENTIFIER , '(' , [ ARG_LIST ] , ')';
 ARG_LIST = EXPRESSION , { ',' , EXPRESSION };
 PIPE_EXPRESSION =  '[' , ARG_LIST , ']' , '>>' , PIPE_FUNCTION , { '>>' , PIPE_FUNCTION };
 PIPE_FUNCTION = IDENTIFIER , [ '(' , [ FUNC_ARG_LIST ] , ')' ];
 
-LITERAL = NUMBER | STRING | BOOL | ARRAY | SET | MAP 'null';
+LITERAL = NUMBER | STR | BOOL | ARRAY | SET | MAP | 'null' | ENTITY_LITERAL | ANONYMOUS_FUNCTION;
 ```
 
 ### Statements
@@ -119,7 +130,7 @@ EACH_STATEMENT = 'each' , IDENTIFIER , 'in' , EXPRESSION , '{' , { STATEMENT } ,
 RANGE_STATEMENT = 'range' , IDENTIFIER , 'in' , EXPRESSION , 'to' , EXPRESSION , [ 'by' , EXPRESSION ] , '{' , { STATEMENT } , '}';
 HALT_STATEMENT = 'halt' , ';';
 SKIP_STATEMENT = 'skip' , ';';
-ECHO_STATEMENT = 'echo' , STRING , ';';
+ECHO_STATEMENT = 'echo' , STR , ';';
 EXPRESSION_STATEMENT = EXPRESSION , ';';
 BLOCK_STATEMENT = '{' , { STATEMENT } , '}';
 ```

--- a/src/frontend/lexer/tokens.py
+++ b/src/frontend/lexer/tokens.py
@@ -22,10 +22,12 @@ class TokenType(Enum):
     INT = auto()  # "int"
     FLOAT = auto()  # "float"
     BOOL = auto()  # "bool"
-    STRING = auto()  # "string"
+    STR = auto()  # "str"
     NULL = auto()  # "null"
     INFER = auto()  # "infer"
     VOID = auto()  # "void"
+    TEMPLATE = auto()  # "template"
+    ENTITY = auto()  # "entity"
 
     # Identifiers
     IDENTIFIER = auto()
@@ -48,7 +50,7 @@ class TokenType(Enum):
     # Literals
     INT_LITERAL = auto()
     FLOAT_LITERAL = auto()
-    BOOL_LITERAL = auto()
+    BOOLEAN_LITERAL = auto()
     NULL_LITERAL = auto()
     STRING_LITERAL = auto()
 
@@ -117,9 +119,11 @@ spec = (
     (TokenType.INT, r"\bint\b"),
     (TokenType.FLOAT, r"\bfloat\b"),
     (TokenType.BOOL, r"\bbool\b"),
-    (TokenType.STRING, r"\bstring\b"),
+    (TokenType.STR, r"\bstr\b"),
     (TokenType.INFER, r"\binfer\b"),
     (TokenType.VOID, r"\bvoid\b"),
+    (TokenType.TEMPLATE, r"\btemplate\b"),
+    (TokenType.ENTITY, r"\bentity\b"),
     (TokenType.LPAREN, r"\("),
     (TokenType.RPAREN, r"\)"),
     (TokenType.LBRACE, r"\{"),
@@ -154,7 +158,7 @@ spec = (
     (TokenType.MINUS, r"-"),
     (TokenType.MULTIPLY, r"\*"),
     (TokenType.DIVIDE, r"/"),
-    (TokenType.BOOL_LITERAL, r"\btrue\b|\bfalse\b"),
+    (TokenType.BOOLEAN_LITERAL, r"\btrue\b|\bfalse\b"),
     (TokenType.NULL_LITERAL, r"\bnull\b"),
     (TokenType.FLOAT_LITERAL, r"\d+\.\d+"),
     (TokenType.INT_LITERAL, r"\d+"),

--- a/src/frontend/parser/parser.py
+++ b/src/frontend/parser/parser.py
@@ -4,6 +4,7 @@ from frontend.lexer.tokens import TokenType
 from frontend.syntax.ast import Program
 from frontend.parser.typing import ParserABC
 from frontend.parser.statements import StatementParser
+from frontend.semantic.types import *
 
 
 class Parser(ParserABC):
@@ -74,6 +75,20 @@ class Parser(ParserABC):
 
         return self.tokens[self.pos]
 
+    def peek(self) -> Token:
+        """Retrieves the token at the next position.
+
+        Returns:
+            Token: The next token.
+
+        Raises:
+            RuntimeError: If the end of the token list is overrun.
+        """
+        if self.pos + 1 >= len(self.tokens):
+            raise RuntimeError("End of file reached")
+
+        return self.tokens[self.pos + 1]
+
     def is_eof(self) -> bool:
         """Checks if the current token is the end-of-file token.
 
@@ -81,3 +96,128 @@ class Parser(ParserABC):
             bool: True if the current token is EOF, otherwise False.
         """
         return self.current().token_type == TokenType.EOF
+
+    # Private methods
+    def parse_var_type(self) -> VarType:
+        """Parses a variable type.
+        Delegates to _parse_function_type if the `func` keyword is encountered.
+
+        Returns:
+            VarType: The parsed variable type.
+        """
+        if self.current().token_type == TokenType.FUNC:
+            return self.parse_function_type()
+
+        match self.current().token_type:
+            case TokenType.INT:
+                var_type = PrimitiveType(self.consume(TokenType.INT).token_type)
+            case TokenType.FLOAT:
+                var_type = PrimitiveType(self.consume(TokenType.FLOAT).token_type)
+            case TokenType.STR:
+                var_type = PrimitiveType(self.consume(TokenType.STR).token_type)
+            case TokenType.BOOL:
+                var_type = PrimitiveType(self.consume(TokenType.BOOL).token_type)
+            case TokenType.INFER:
+                var_type = InferType()
+                self.consume(TokenType.INFER)
+            case TokenType.IDENTIFIER:
+                var_type = CustomType(self.consume(TokenType.IDENTIFIER).value)
+
+            case _:
+                raise SyntaxError(f"Unexpected token {self.current()}")
+
+        while self.current().token_type in (
+            TokenType.LBRACKET,
+            TokenType.LBRACE,
+        ):
+            if self.current().token_type == TokenType.LBRACKET:
+                var_type = self.parse_array_type(var_type)
+            if self.current().token_type == TokenType.LBRACE:
+                var_type = self.parse_set_or_map_type(var_type)
+
+        return var_type
+
+    def parse_array_type(self, var_type: VarType) -> VarType:
+        """Parses an array type.
+
+        Args:
+            var_type (VarType): The base type of the array.
+
+        Returns:
+            VarType: The parsed array type.
+        """
+        new_type = var_type
+
+        while self.current().token_type == TokenType.LBRACKET:
+            self.consume(TokenType.LBRACKET)
+            self.consume(TokenType.RBRACKET)
+
+            new_type = ArrayType(new_type)
+
+        return new_type
+
+    def parse_set_or_map_type(self, var_type: VarType) -> VarType:
+        """Parses a set or map type.
+
+        Args:
+            var_type (VarType): The base type of the set or map.
+
+        Returns:
+            VarType: The parsed set or map type.
+        """
+        new_type = var_type
+
+        while self.current().token_type == TokenType.LBRACE:
+            self.consume(TokenType.LBRACE)
+            if self.current().token_type == TokenType.RBRACE:
+                self.consume(TokenType.RBRACE)
+
+                new_type = SetType(var_type)
+            else:
+                key_type = self.parse_var_type()
+                self.consume(TokenType.RBRACE)
+
+                new_type = MapType(key_type, var_type)
+
+        return new_type
+
+    def parse_return_type(self) -> VarType:
+        """Parses a return type for a function declaration.
+        Extends the _parse_var_type method to handle the `void` keyword.
+
+        Returns:
+            VarType: The parsed return type.
+        """
+        if self.current().token_type == TokenType.VOID:
+            self.consume(TokenType.VOID)
+            return VoidType()
+
+        return self.parse_var_type()
+
+    def parse_function_type(self) -> FunctionType:
+        """Parses a function type.
+
+        Returns:
+            FunctionType: The parsed function type.
+        """
+        self.consume(TokenType.FUNC)
+        self.consume(TokenType.LT)
+
+        return_type = self.parse_return_type()
+
+        self.consume(TokenType.COMMA)
+        self.consume(TokenType.LBRACKET)
+
+        parameters: List[Tuple[str, VarType]] = []
+        while self.current().token_type != TokenType.RBRACKET:
+            var_type = self.parse_var_type()
+            identifier = self.consume(TokenType.IDENTIFIER).value
+            parameters.append((identifier, var_type))
+
+            if self.current().token_type == TokenType.COMMA:
+                self.consume(TokenType.COMMA)
+
+        self.consume(TokenType.RBRACKET)
+        self.consume(TokenType.GT)
+
+        return FunctionType(return_type, parameters)

--- a/src/frontend/parser/typing.py
+++ b/src/frontend/parser/typing.py
@@ -55,6 +55,10 @@ class ExpressionParserABC(Protocol):
         """Parses a map literal."""
 
     @abstractmethod
+    def parse_entity_literal(self, template: str) -> Expression:
+        """Parses an object literal."""
+
+    @abstractmethod
     def parse_index_expression(self, array: Expression) -> IndexExpression:
         """Parses an index expression."""
 
@@ -93,6 +97,10 @@ class StatementParserABC(Protocol):
     @abstractmethod
     def parse_variable_declaration(self) -> VariableDeclaration:
         """Parses a variable declaration statement."""
+
+    # @abstractmethod
+    # def parse_entity_declaration(self) -> VariableDeclaration:
+    #     """Parses an entity declaration statement."""
 
     @abstractmethod
     def parse_block_statement(self) -> BlockStatement:
@@ -154,5 +162,29 @@ class ParserABC(ABC):
         """Retrieves the token at the current position."""
 
     @abstractmethod
+    def peek(self) -> Token:
+        """Retrieves the token at the next position."""
+
+    @abstractmethod
     def is_eof(self) -> bool:
         """Checks if the current token is the end-of-file token."""
+
+    @abstractmethod
+    def parse_var_type(self) -> VarType:
+        """Parses a variable type."""
+
+    @abstractmethod
+    def parse_array_type(self, var_type: VarType) -> VarType:
+        """Parses an array type."""
+
+    @abstractmethod
+    def parse_set_or_map_type(self, var_type: VarType) -> VarType:
+        """Parses a set or map type."""
+
+    @abstractmethod
+    def parse_return_type(self) -> VarType:
+        """Parses a return type for a function declaration."""
+
+    @abstractmethod
+    def parse_function_type(self) -> FunctionType:
+        """Parses a function type."""

--- a/src/frontend/semantic/analyzer.py
+++ b/src/frontend/semantic/analyzer.py
@@ -21,7 +21,7 @@ class SemanticAnalyzer(SemanticAnalyzerABC):
 
     def __init__(self) -> None:
         self.symbol_table = SymbolTable()
-        self.statement_analzyer = StatementAnalyzer(self)
+        self.statement_analyzer = StatementAnalyzer(self)
         self.expression_analyzer = ExpressionAnalyzer(self)
 
     def analyze(self, node: Node) -> VarType:
@@ -43,7 +43,7 @@ class SemanticAnalyzer(SemanticAnalyzerABC):
 
         analyzer = self
         if isinstance(node, Statement):
-            analyzer = self.statement_analzyer
+            analyzer = self.statement_analyzer
         elif isinstance(node, Expression):
             analyzer = self.expression_analyzer
 

--- a/src/frontend/semantic/symbol.py
+++ b/src/frontend/semantic/symbol.py
@@ -1,5 +1,5 @@
 from typing import *
-from frontend.semantic.types import FunctionType, VarType
+from frontend.semantic.types import *
 from frontend.semantic.typing import ScopeABC, SymbolABC, SymbolTableABC
 from frontend.syntax.ast import *
 
@@ -27,11 +27,11 @@ class Scope(ScopeABC):
 
     Attributes:
         symbols (Dict[str, Symbol]): A dictionary mapping names to symbols.
-        parent_node (Optional[Statement]): The parent node of the scope, if any.
+        parent_node (Optional[Node]): The parent node of the scope, if any.
         reachable (bool): True if the scope is reachable, otherwise False.
     """
 
-    def __init__(self, parent_node: Optional[Statement] = None) -> None:
+    def __init__(self, parent_node: Optional[Node] = None) -> None:
         self.symbols: Dict[str, SymbolABC] = {}
         self.parent_node = parent_node
         self.reachable = True
@@ -55,7 +55,7 @@ class SymbolTable(SymbolTableABC):
         """Initializes the symbol table with an empty global scope."""
         self.scopes: List[ScopeABC] = [Scope()]
 
-    def enter_scope(self, parent_node: Optional[Statement] = None) -> None:
+    def enter_scope(self, parent_node: Optional[Node] = None) -> None:
         """Enters a new scope, optionally as a function scope.
 
         Args:
@@ -132,6 +132,8 @@ class SymbolTable(SymbolTableABC):
         for scope in reversed(self.scopes):
             if isinstance(scope.parent_node, FunctionDeclaration):
                 return scope.parent_node.function_type
+            if isinstance(scope.parent_node, FunctionLiteral):
+                return FunctionType(InferType(), scope.parent_node.parameters)
 
         return None
 

--- a/src/frontend/semantic/typing.py
+++ b/src/frontend/semantic/typing.py
@@ -15,7 +15,7 @@ class ScopeABC(Protocol):
     """Abstract class for symbol table scopes."""
 
     symbols: Dict[str, SymbolABC]
-    parent_node: Optional[Statement]
+    parent_node: Optional[Node]
     reachable: bool
 
 
@@ -25,7 +25,7 @@ class SymbolTableABC(ABC):
     scopes: List[ScopeABC]
 
     @abstractmethod
-    def enter_scope(self, parent_node: Optional[Statement] = None) -> None:
+    def enter_scope(self, parent_node: Optional[Node] = None) -> None:
         """Push a new scope onto the stack."""
 
     @abstractmethod
@@ -59,74 +59,6 @@ class SymbolTableABC(ABC):
     @abstractmethod
     def set_unreachable(self) -> None:
         """Set the current scope to unreachable."""
-
-
-class SemanticAnalyzerABC(ABC):
-    """Abstract class for the semantic analyzer."""
-
-    symbol_table: SymbolTableABC
-
-    @abstractmethod
-    def analyze(self, node: Node) -> VarType:
-        """Analyze a node in the AST."""
-
-    @abstractmethod
-    def analyze_generic(self, node: Node) -> VarType:
-        """Analyze a node of an unknown type."""
-
-    @abstractmethod
-    def analyze_program(self, node: Program) -> VoidType:
-        """Analyze a program node."""
-
-
-class StatementAnalyzerABC(ABC):
-    """Abstract class for the statement analyzer."""
-
-    @abstractmethod
-    def analyze_variable_declaration(self, node: VariableDeclaration) -> VarType:
-        """Analyze a variable declaration statement."""
-
-    @abstractmethod
-    def analyze_function_declaration(self, node: FunctionDeclaration) -> VarType:
-        """Analyze a function declaration statement."""
-
-    @abstractmethod
-    def analyze_block_statement(
-        self, node: BlockStatement, new_scope: bool = True
-    ) -> VoidType:
-        """Analyze a block statement."""
-
-    @abstractmethod
-    def analyze_if_statement(self, node: IfStatement) -> VoidType:
-        """Analyze an if statement."""
-
-    @abstractmethod
-    def analyze_while_statement(self, node: WhileStatement) -> VoidType:
-        """Analyze a while statement."""
-
-    @abstractmethod
-    def analyze_range_statement(self, node: RangeStatement) -> VoidType:
-        """Analyze a range statement."""
-
-    @abstractmethod
-    def analyze_each_statement(self, node: EachStatement) -> VoidType:
-        """Analyze an each statement."""
-
-    @abstractmethod
-    def analyze_halt_statement(self, node: HaltStatement) -> VoidType:
-        """Analyze a halt statement."""
-
-    @abstractmethod
-    def analyze_skip_statement(self, node: SkipStatement) -> VoidType:
-        """Analyze a skip statement."""
-
-    @abstractmethod
-    def analyze_echo_statement(self, node: EchoStatement) -> VoidType:
-        """Analyze an echo statement."""
-
-    @abstractmethod
-    def analyze_return_statement(self, node: ReturnStatement) -> VarType:
-        """Analyze a return statement."""
 
 
 class ExpressionAnalyzerABC(ABC):
@@ -187,3 +119,81 @@ class ExpressionAnalyzerABC(ABC):
     @abstractmethod
     def _is_assignable(self, node: Expression) -> bool:
         """Check if an expression is assignable."""
+
+
+class StatementAnalyzerABC(ABC):
+    """Abstract class for the statement analyzer."""
+
+    @abstractmethod
+    def analyze_variable_declaration(self, node: VariableDeclaration) -> VarType:
+        """Analyze a variable declaration statement."""
+
+    @abstractmethod
+    def analyze_function_declaration(self, node: FunctionDeclaration) -> FunctionType:
+        """Analyze a function declaration statement."""
+
+    @abstractmethod
+    def analyze_template_declaration(self, node: TemplateDeclaration) -> VarType:
+        """Analyses a TemplateDeclaration statement."""
+
+    @abstractmethod
+    def analyze_block_statement(
+        self, node: BlockStatement, new_scope: bool = True
+    ) -> VoidType:
+        """Analyze a block statement."""
+
+    @abstractmethod
+    def analyze_if_statement(self, node: IfStatement) -> VoidType:
+        """Analyze an if statement."""
+
+    @abstractmethod
+    def analyze_while_statement(self, node: WhileStatement) -> VoidType:
+        """Analyze a while statement."""
+
+    @abstractmethod
+    def analyze_range_statement(self, node: RangeStatement) -> VoidType:
+        """Analyze a range statement."""
+
+    @abstractmethod
+    def analyze_each_statement(self, node: EachStatement) -> VoidType:
+        """Analyze an each statement."""
+
+    @abstractmethod
+    def analyze_halt_statement(self, node: HaltStatement) -> VoidType:
+        """Analyze a halt statement."""
+
+    @abstractmethod
+    def analyze_skip_statement(self, node: SkipStatement) -> VoidType:
+        """Analyze a skip statement."""
+
+    @abstractmethod
+    def analyze_echo_statement(self, node: EchoStatement) -> VoidType:
+        """Analyze an echo statement."""
+
+    @abstractmethod
+    def analyze_return_statement(self, node: ReturnStatement) -> VarType:
+        """Analyze a return statement."""
+
+    @abstractmethod
+    def get_return_type(self, node: ReturnStatement) -> VarType:
+        """Get the return type of a return statement."""
+
+
+class SemanticAnalyzerABC(ABC):
+    """Abstract class for the semantic analyzer."""
+
+    symbol_table: SymbolTableABC
+    statement_analyzer: StatementAnalyzerABC
+    expression_analyzer: ExpressionAnalyzerABC
+
+    @abstractmethod
+    def analyze(self, node: Node) -> VarType:
+        """Analyze a node in the AST."""
+
+    @abstractmethod
+    def analyze_generic(self, node: Node) -> VarType:
+        """Analyze a node of an unknown type."""
+
+    @abstractmethod
+    def analyze_program(self, node: Program) -> VoidType:
+        """Analyze a program node."""

--- a/src/frontend/syntax/ast.py
+++ b/src/frontend/syntax/ast.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union, Literal, Tuple
 from abc import ABC
 from frontend.lexer.tokens import TokenType
-from frontend.semantic.types import FunctionType, VarType
+from frontend.semantic.types import *
 
 
 class Node(ABC):
@@ -331,6 +331,42 @@ class EchoStatement(Statement):
         return f"EchoStatement({self.expression})"
 
 
+class TemplateDeclaration(Statement):
+    """Node representing a template declaration.
+
+    Args:
+        name (str): The name of the template.
+        attributes (List[Tuple[str, VarType]]): The attributes of the template.
+        methods (List[FunctionDeclaration]): The methods of the template.
+
+    Syntax:
+        template <name> = { <attributes> <methods> }
+
+    Example:
+        template Person = {
+            str name;
+            int age;
+
+            func greet -> void = [] >> {
+                echo "Hello!";
+            }
+        }
+    """
+
+    def __init__(
+        self,
+        name: str,
+        attributes: Dict[str, VarType],
+        methods: Dict[str, FunctionDeclaration],
+    ) -> None:
+        self.name = name
+        self.attributes = attributes
+        self.methods = methods
+
+    def __repr__(self) -> str:
+        return f"TemplateDeclaration({self.name}, {self.attributes}, {self.methods})"
+
+
 # Expressions
 class NumericLiteral(Expression):
     """Node representing a numeric literal.
@@ -426,6 +462,22 @@ class MapLiteral(Expression):
         return f"MapLiteral({self.elements})"
 
 
+class EntityLiteral(Expression):
+    """Node representing an entity literal.
+
+    Args:
+        template (str): The template of the entity.
+        elements (Dict[str, Expression]]): The elements of the entity.
+    """
+
+    def __init__(self, template: CustomType, attributes: Dict[str, Expression]) -> None:
+        self.template = template
+        self.attributes = attributes
+
+    def __repr__(self) -> str:
+        return f"EntityLiteral({self.template}, {self.attributes})"
+
+
 class Identifier(Expression):
     """Node representing an identifier.
 
@@ -510,6 +562,24 @@ class IndexExpression(Expression):
         return f"IndexExpression({self.array}, {self.index})"
 
 
+class FunctionLiteral(Expression):
+    """Node representing an function literal.
+
+    Args:
+        parameters (List[Tuple[str, VarType]]): The parameters of the function.
+        body (BlockStatement): The block to be executed when the function is called.
+    """
+
+    def __init__(
+        self, parameters: List[Tuple[str, VarType]], body: BlockStatement
+    ) -> None:
+        self.parameters = parameters
+        self.body = body
+
+    def __repr__(self) -> str:
+        return f"FunctionLiteral({self.parameters}, {self.body})"
+
+
 class FunctionCallExpression(Expression):
     """Node representing a function call expression.
 
@@ -530,7 +600,7 @@ class MemberAccessExpression(Expression):
     """Node representing a member access expression.
 
     Args:
-        object (Expression): The object to access the member from.
+        obj (Expression): The object to access the member from.
         member (Identifier): The member to be accessed.
     """
 

--- a/tests/semantic/test_functions.py
+++ b/tests/semantic/test_functions.py
@@ -65,7 +65,7 @@ def test_invalid_function_call():
 
 def test_invalid_return_usage():
     code = """
-        if true {
+        if (true) {
             return 5; // Return statement should only be valid inside a function
         }
     """
@@ -81,10 +81,10 @@ def test_complex_function():
         func multiply -> int = [int x, int y] >> {
             return x * y;
         }
-        if z > 10 {
+        if (z > 10) {
             z = multiply(z, 2);
         }
-        while z > 0 {
+        while (z > 0) {
             z = z - 1;
         }
     """
@@ -103,7 +103,7 @@ def test_pipe_expression():
 
         func reduce -> int = [int[] arr, func<int, [int a, int b]> fn] >> {
             int result = 0;
-            each x in arr {
+            each (x in arr) {
                 result = fn(result, x);
             }
             return result;
@@ -112,6 +112,7 @@ def test_pipe_expression():
         int x = [[1, 2, 3, 4]] >> reduce(add) >> triple;
     """
     analyze_code(code)
+
     code = """
         func add -> int = [int a, int b] >> {
             return a + b;
@@ -123,7 +124,7 @@ def test_pipe_expression():
 
         func reduce -> int = [int[] arr, func<int, [int a, int b]> fn] >> {
             int result = 0;
-            each x in arr {
+            each (x in arr) {
                 result = fn(result, x);
             }
             return result;
@@ -144,25 +145,41 @@ def test_function_parameter_types():
     """
     with pytest.raises(
         TypeError,
-        match=r"Argument type `PrimitiveType\(STRING\)` does not match parameter type `PrimitiveType\(INT\)`",
+        match=r"Argument type `PrimitiveType\(STR\)` does not match parameter type `PrimitiveType\(INT\)`",
     ):
         analyze_code(code)
 
 
 def test_function_return_type():
     code = """
-        func greet -> string = [string name] >> {
+        func greet -> str = [str name] >> {
             return "Hello, " + name;
         }
-        string message = greet("World");
+        str message = greet("World");
     """
     analyze_code(code)
+
+
+def test_infer_function_return_type():
+    code = """
+        func greet -> infer = [str name] >> {
+            return "Hello, " + name;
+        }
+        
+        int x = greet("World");  // Type mismatch
+    """
+
+    with pytest.raises(
+        TypeError,
+        match=r"Type mismatch for variable `x`: `PrimitiveType\(INT\)` != `PrimitiveType\(STR\)`",
+    ):
+        analyze_code(code)
 
 
 def test_recursive_function():
     code = """
         func factorial -> int = [int n] >> {
-            if n <= 1 {
+            if (n <= 1) {
                 return 1;
             } else {
                 return n * factorial(n - 1);
@@ -177,7 +194,7 @@ def test_function_with_array_parameter():
     code = """
         func sum -> int = [int[] arr] >> {
             int result = 0;
-            each x in arr {
+            each (x in arr) {
                 result = result + x;
             }
             return result;
@@ -201,6 +218,130 @@ def test_function_with_nested_call():
     analyze_code(code)
 
 
+def test_function_literal():
+    code = """
+        func square -> int = [int x] >> {
+            return x * x;
+        }
+        func apply -> int = [func<int, [int x]> fn, int y] >> {
+            return fn(y);
+        }
+        int result = apply(func [int x] >> { return x * 2; }, 5);
+    """
+    analyze_code(code)
+
+
+def test_template_declaration():
+    code = """
+        template Person = {
+            str name;
+            int age;
+            
+            func greet -> str = [] >> {
+                return "Hello";
+            }
+        };
+    """
+    analyze_code(code)
+
+
+def test_nested_template_declaration():
+    code = """
+        template User = {
+            str name;
+            int age;
+            User[] followers;
+        };
+    """
+    analyze_code(code)
+
+
+def test_entity_declaration():
+    code = """
+        template Point = {
+            int x;
+            int y;
+            
+            func move -> void = [int dx, int dy] >> {
+                x = x + dx;
+                y = y + dy;
+            }
+        };
+        
+        entity pt = Point{x: 1, y: 2};
+        
+        pt.move(2, 3);
+    """
+    analyze_code(code)
+
+
+def test_invalid_entity_declaration():
+    code = """
+        template Point = {
+            int x;
+            int y;
+            
+            func move -> void = [int dx, int dy] >> {
+                x = x + dx;
+                y = y + dy;
+            }
+        };
+        
+        entity point = Point{
+            x: 1,
+            z: 2,  // Invalid field
+        };
+    """
+    with pytest.raises(
+        NameError, match=r"Attribute `z` not defined in template `Point`"
+    ):
+        analyze_code(code)
+
+
+def test_nested_entity_declaration():
+    code = """
+        template User = {
+            str name;
+            int age;
+            User[] followers;
+        };
+        
+        entity user = User{
+            name: "James",
+            age: 25,
+            followers: [
+                User{name: "Bob", age: 30, followers: []},
+                User{name: "Charlie", age: 35, followers: []}
+            ],
+        };
+    """
+    analyze_code(code)
+
+
+def test_invalid_nested_entity_declaration():
+    code = """
+        template User = {
+            str name;
+            int age;
+            User[] followers;
+        };
+        
+        entity user = User{
+            name: "James",
+            age: 25,
+            followers: [
+                User{name: "Bob", age: 30, followers: 2}, // Invalid `followers` type
+                User{name: "Charlie", age: 35, followers: []}
+            ],
+        };
+    """
+    with pytest.raises(
+        TypeError,
+        match=r"Type mismatch for attribute `followers`: `ArrayType\(CustomType\(User\)\)` != `PrimitiveType\(INT\)`"
+    ):
+        analyze_code(code)
+
+
 def test_set_method_call_expression():
     code = """
         int{} x = {1, 2, 3};
@@ -212,44 +353,53 @@ def test_set_method_call_expression():
 
 def test_map_method_call_expression():
     code = """
-        int{string} x = {"a": 1, "b": 2};
+        int{str} x = {"a": 1, "b": 2};
         int y = x.put("c", 3).remove("a").get("b");
-        int{string} z = x.clear();
+        int{str} z = x.clear();
     """
     analyze_code(code)
+
 
 def test_method_access_on_invalid_type():
     code = """
         int x = 5;
         x.add(4);  // Method call on non-object type
     """
-    with pytest.raises(TypeError, match=r"Type `PrimitiveType\(INT\)` does not have methods"):
+    with pytest.raises(
+        TypeError, match=r"Type `PrimitiveType\(INT\)` does not have methods"
+    ):
         analyze_code(code)
-        
+
+
 def test_undeclared_method_access():
     code = """
         int{} x = {1, 2, 3};
-        x.put(4);  // Method `put` is not defined on type `SetType\(PrimitiveType\(INT\)\)`
+        x.put(4);  // `put` is not a valid set method
     """
-    with pytest.raises(TypeError, match=r"Method `put` is not defined on type `SetType\(PrimitiveType\(INT\)\)`"):
+    with pytest.raises(
+        TypeError,
+        match=r"Method `put` is not defined on type `SetType\(PrimitiveType\(INT\)\)`",
+    ):
         analyze_code(code)
-        
+
+
 def test_missing_method_arguments():
     code = """
-        int{string} x = {"a": 1, "b": 2};
+        int{str} x = {"a": 1, "b": 2};
         x.put("c");  // Missing argument
     """
     with pytest.raises(TypeError, match=r"Method `put` expects 2 arguments, got 1"):
         analyze_code(code)
-        
+
+
 def test_invalid_method_argument_types():
     code = """
-        int{string} x = {"a": 1, "b": 2};
+        int{str} x = {"a": 1, "b": 2};
         x.put(3, "c");  // Type mismatch in method arguments
     """
-    
+
     with pytest.raises(
         TypeError,
-        match=r"Argument type `PrimitiveType\(INT\)` does not match parameter type `PrimitiveType\(STRING\)`",
+        match=r"Argument type `PrimitiveType\(INT\)` does not match parameter type `PrimitiveType\(STR\)`",
     ):
         analyze_code(code)

--- a/tests/semantic/test_scope.py
+++ b/tests/semantic/test_scope.py
@@ -117,7 +117,7 @@ def test_nested_blocks_and_scopes():
 def test_if_else():
     code = """
         int x = 5;
-        if x > 3 {
+        if (x > 3) {
             echo "greater";
         } else {
             echo "smaller";
@@ -129,7 +129,7 @@ def test_if_else():
 def test_while_loop():
     code = """
         int x = 0;
-        while x < 10 {
+        while (x < 10) {
             x++;
         }
     """
@@ -138,7 +138,7 @@ def test_while_loop():
 
 def test_each_statement():
     code = """
-        each x in [1, 2, 3] {
+        each (x in [1, 2, 3]) {
             echo x;
         }
     """
@@ -147,7 +147,7 @@ def test_each_statement():
 
 def test_range_statement():
     code = """
-        range x in 0 to 10 by 1 {
+        range (x in 0 to 10 by 1) {
             echo x;
         }
     """
@@ -157,9 +157,9 @@ def test_range_statement():
 def test_halt_statement():
     code = """
         int x = 0;
-        while x < 10 {
+        while (x < 10) {
             x++;
-            if x == 5 {
+            if (x == 5) {
                 halt; // halt execution of the loop
             }
             echo x;
@@ -170,7 +170,7 @@ def test_halt_statement():
 
 def test_invalid_skip_statement():
     code = """
-        if true {
+        if (true) {
             skip; // skip statement is only allowed in loop scopes
         }
     """
@@ -240,7 +240,7 @@ def test_return_statement_reachability():
 
 def test_halt_statement_reachability():
     code = """
-        while true {
+        while (true) {
             halt;
             echo "This should be unreachable";  // Unreachable code
         }
@@ -251,7 +251,7 @@ def test_halt_statement_reachability():
 
 def test_skip_statement_reachability():
     code = """
-        while true {
+        while (true) {
             skip;
             echo "This should be unreachable";  // Unreachable code
         }
@@ -265,10 +265,10 @@ def test_valid_control_flow_statement_use():
         func main -> int = [] >> {
             int x = 0;
 
-            while x < 10 {
+            while (x < 10) {
                 x++;
-                if x == 5 { skip; }
-                if x == 7 { halt; }
+                if (x == 5) { skip; }
+                if (x == 7) { halt; }
                 echo x;
             }
 
@@ -285,8 +285,8 @@ def test_nested_if_else_reachability():
         func foo -> void = [] >> {
             int x = 5;
 
-            if x > 3 {
-                if x < 10 {
+            if (x > 3) {
+                if (x < 10) {
                     return;
                 } else {
                     return;
@@ -305,7 +305,7 @@ def test_nested_if_else_reachability():
 def test_unreachable_if_block():
     code = """
         func foo -> void = [] >> {
-            if false {
+            if (false) {
                 echo "This should be unreachable";  // Unreachable code
             } else {
                 return;
@@ -319,7 +319,7 @@ def test_unreachable_if_block():
 def test_unreachable_else_block():
     code = """
         func foo -> void = [] >> {
-            if true {
+            if (true) {
                 return;
             } else {
                 echo "This should be unreachable";  // Unreachable code

--- a/tests/semantic/test_types.py
+++ b/tests/semantic/test_types.py
@@ -24,7 +24,7 @@ def test_type_error():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch for variable `x`: `PrimitiveType\(INT\)` != `PrimitiveType\(STRING\)`",
+        match=r"Type mismatch for variable `x`: `PrimitiveType\(INT\)` != `PrimitiveType\(STR\)`",
     ):
         analyze_code(code)
 
@@ -36,7 +36,7 @@ def test_conflicting_infer_type():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch in assignment expression: PrimitiveType\(INT\) != PrimitiveType\(STRING\)",
+        match=r"Type mismatch in assignment expression: PrimitiveType\(INT\) != PrimitiveType\(STR\)",
     ):
         analyze_code(code)
 
@@ -49,7 +49,7 @@ def test_conflicting_complex_infer_type():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch in assignment expression: PrimitiveType\(INT\) != PrimitiveType\(STRING\)",
+        match=r"Type mismatch in assignment expression: PrimitiveType\(INT\) != PrimitiveType\(STR\)",
     ):
         analyze_code(code)
 
@@ -61,7 +61,7 @@ def test_conflicting_infer_array_type():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch in assignment expression: ArrayType\(PrimitiveType\(INT\)\) != PrimitiveType\(STRING\)",
+        match=r"Type mismatch in assignment expression: ArrayType\(PrimitiveType\(INT\)\) != PrimitiveType\(STR\)",
     ):
         analyze_code(code)
 
@@ -82,7 +82,7 @@ def test_invalid_return_type():
     """
     with pytest.raises(
         TypeError,
-        match=r"Return type `PrimitiveType\(STRING\)` does not match function return type `PrimitiveType\(INT\)`",
+        match=r"Return type `PrimitiveType\(STR\)` does not match function return type `PrimitiveType\(INT\)`",
     ):
         analyze_code(code)
 
@@ -96,7 +96,7 @@ def test_invalid_function_call_type():
     """
     with pytest.raises(
         TypeError,
-        match=r"Argument type `PrimitiveType\(STRING\)` does not match parameter type `PrimitiveType\(INT\)`",
+        match=r"Argument type `PrimitiveType\(STR\)` does not match parameter type `PrimitiveType\(INT\)`",
     ):
         analyze_code(code)
 
@@ -108,7 +108,7 @@ def test_invalid_array_type():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch in assignment expression: PrimitiveType\(INT\) != PrimitiveType\(STRING\)",
+        match=r"Type mismatch in assignment expression: PrimitiveType\(INT\) != PrimitiveType\(STR\)",
     ):
         analyze_code(code)
 
@@ -124,7 +124,7 @@ def test_invalid_set_type():
 
 def test_invalid_map_key_type():
     code = """
-        int{string} map = {1: 1, 'world': 2};
+        int{str} map = {1: 1, 'world': 2};
     """
 
     with pytest.raises(TypeError, match=r"Invalid key type in map literal"):
@@ -133,7 +133,7 @@ def test_invalid_map_key_type():
 
 def test_invalid_map_value_type():
     code = """
-        int{string} map = {'hello': 1, 'world': 'invalid'};
+        int{str} map = {'hello': 1, 'world': 'invalid'};
     """
 
     with pytest.raises(TypeError, match=r"Invalid value type in map literal"):
@@ -188,7 +188,7 @@ def test_infer_array_type():
     code = """
         infer x = [1, 2, 3];
 
-        each y in x {
+        each (y in x) {
             echo y + 1;
         }
     """
@@ -201,7 +201,7 @@ def test_binary_expression_type_mismatch():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch in binary expression: PrimitiveType\(INT\) != PrimitiveType\(STRING\)",
+        match=r"Type mismatch in binary expression: PrimitiveType\(INT\) != PrimitiveType\(STR\)",
     ):
         analyze_code(code)
 
@@ -241,7 +241,7 @@ def test_function_return_type_mismatch():
     """
     with pytest.raises(
         TypeError,
-        match=r"Return type `PrimitiveType\(STRING\)` does not match function return type `PrimitiveType\(INT\)`",
+        match=r"Return type `PrimitiveType\(STR\)` does not match function return type `PrimitiveType\(INT\)`",
     ):
         analyze_code(code)
 
@@ -261,6 +261,12 @@ def test_array_index_type_mismatch():
     """
     with pytest.raises(TypeError, match=r"Array index must be an integer"):
         analyze_code(code)
+        
+def test_empty_array_declaration():
+    code = """
+        int[] arr = [];
+    """
+    analyze_code(code)
 
 
 def test_invalid_logical_operation():

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -103,7 +103,7 @@ def test_invalid_set_literal():
     
 
 def test_invalid_map_literal():
-    code = "int{string} x = {'a': 1, 'b', 'c': 3};"
+    code = "int{str} x = {'a': 1, 'b', 'c': 3};"
     check(code, "Expected token TokenType.COLON, but got TokenType.COMMA")
 
 
@@ -138,5 +138,5 @@ def test_extra_comma_in_function_call():
 
 
 def test_invalid_range_statement():
-    code = "range x in 0 to 10 step 2 { return x; }"
-    check(code, "Expected token TokenType.LBRACE, but got TokenType.IDENTIFIER")
+    code = "range (x in 0 to 10 step 2) { return x; }"
+    check(code, "Expected token TokenType.RPAREN, but got TokenType.IDENTIFIER")


### PR DESCRIPTION
- adds templates and entities
  - adds `template` and `entity` keywords
  - adds relevant parser and semantic analyser methods (with tests)
  - adds concept of a `CustomType`, which serves as an identifier for templates
- changes syntax to require parentheses around `if`, `while`, `each`, and `range` conditions
  - required in order to parse entity literals 
- adds anonymous functions/function literals
- enables inferred function return types 
- fixes bug where typed variables initialised to empty arrays would throw a type error
- changes `string` keyword to `str` (to align with `int` and `bool`)