### PR TITLE
implement member access analysis

### DIFF
--- a/src/frontend/lexer/tokens.py
+++ b/src/frontend/lexer/tokens.py
@@ -45,7 +45,7 @@ class TokenType(Enum):
     SEMICOLON = auto()  # ";"
     COLON = auto()  # ":"
     ARROW = auto()  # ">>"
-    RETURN_ARROW = auto()  # "->"
+    RT_ARROW = auto()  # "->"
 
     # Literals
     INT_LITERAL = auto()
@@ -135,7 +135,7 @@ spec = (
     (TokenType.SEMICOLON, r";"),
     (TokenType.COLON, r":"),
     (TokenType.ARROW, r">>"),
-    (TokenType.RETURN_ARROW, r"->"),
+    (TokenType.RT_ARROW, r"->"),
     (TokenType.EOL_COMMENT, r"//.*\n"),
     (TokenType.DELIMITED_COMMENT, r"/\*[\s\S]*?(?:\*/|$)"),
     (TokenType.LOGICAL_AND, r"&&"),

--- a/src/frontend/parser/expressions.py
+++ b/src/frontend/parser/expressions.py
@@ -56,7 +56,7 @@ class ExpressionParser(ExpressionParserABC):
             self.parser.consume(TokenType.ASSIGN)
             right = self.parse_assignment_expression()
 
-            if isinstance(left, (Identifier, IndexExpression)):
+            if isinstance(left, (Identifier, IndexExpression, MemberAccessExpression)):
                 return AssignmentExpression(left, right)
 
             raise SyntaxError("Invalid left-hand side in assignment")
@@ -327,7 +327,7 @@ class ExpressionParser(ExpressionParserABC):
 
         self.parser.consume(TokenType.RBRACE)
 
-        return EntityLiteral(CustomType(template), attributes)
+        return EntityLiteral(CustomTypeIdentifier(template), attributes)
 
     def parse_index_expression(self, array: Expression) -> IndexExpression:
         """Parses an index expression for array access.

--- a/src/frontend/parser/parser.py
+++ b/src/frontend/parser/parser.py
@@ -121,7 +121,9 @@ class Parser(ParserABC):
                 var_type = InferType()
                 self.consume(TokenType.INFER)
             case TokenType.IDENTIFIER:
-                var_type = CustomType(self.consume(TokenType.IDENTIFIER).value)
+                var_type = CustomTypeIdentifier(
+                    self.consume(TokenType.IDENTIFIER).value
+                )
 
             case _:
                 raise SyntaxError(f"Unexpected token {self.current()}")

--- a/src/frontend/parser/statements.py
+++ b/src/frontend/parser/statements.py
@@ -131,7 +131,9 @@ class StatementParser(StatementParserABC):
         initializer = self.expression_parser.parse_entity_literal(template)
         self.parser.consume(TokenType.SEMICOLON)
 
-        return VariableDeclaration(name.value, CustomType(template), initializer)
+        return VariableDeclaration(
+            name.value, CustomTypeIdentifier(template), initializer
+        )
 
     def parse_block_statement(self) -> BlockStatement:
         """Parses a block statement.
@@ -274,7 +276,7 @@ class StatementParser(StatementParserABC):
         """
         self.parser.consume(TokenType.FUNC)
         name = self.parser.consume(TokenType.IDENTIFIER)
-        self.parser.consume(TokenType.RETURN_ARROW)
+        self.parser.consume(TokenType.RT_ARROW)
         return_type = self.parser.parse_return_type()
         self.parser.consume(TokenType.ASSIGN)
         self.parser.consume(TokenType.LBRACKET)

--- a/src/frontend/semantic/analyzer.py
+++ b/src/frontend/semantic/analyzer.py
@@ -49,7 +49,15 @@ class SemanticAnalyzer(SemanticAnalyzerABC):
 
         analyze = getattr(analyzer, method_name, self.analyze_generic)
 
-        return analyze(node)
+        node_type = analyze(node)
+
+        if isinstance(node_type, CustomTypeIdentifier):
+            template_symbol = self.symbol_table.lookup(node_type.name)
+            if not template_symbol:
+                raise NameError(f"Type {node_type.name} is not defined.")
+            node_type = template_symbol.var_type
+
+        return node_type
 
     def analyze_generic(self, node: Node) -> VarType:
         """Called if no explicit analyzer function exists for a node.

--- a/src/frontend/semantic/statements.py
+++ b/src/frontend/semantic/statements.py
@@ -39,13 +39,6 @@ class StatementAnalyzer(StatementAnalyzerABC):
 
         if isinstance(node.var_type, InferType):
             node.var_type = init_type  # Infer the variable type from the initializer
-        if isinstance(node.var_type, CustomType):
-            template_symbol = self.analyzer.symbol_table.lookup(
-                node.var_type.name, False
-            )
-            if not template_symbol:
-                raise NameError(f"Template `{node.var_type.name}` not found")
-            node.var_type = template_symbol.var_type
         if node.var_type != init_type:
             raise TypeError(
                 f"Type mismatch for variable `{node.name}`: "
@@ -114,7 +107,9 @@ class StatementAnalyzer(StatementAnalyzerABC):
         if self.analyzer.symbol_table.lookup(node.name, False):
             raise NameError(f"Cannot redeclare template `{node.name}`")
 
-        template_type = TemplateType(CustomType(node.name), node.attributes, {})
+        template_type = TemplateType(
+            CustomTypeIdentifier(node.name), node.attributes, {}
+        )
         for name, declaration in node.methods.items():
             template_type.methods[name] = self.analyze_function_declaration(
                 declaration, template_type

--- a/src/frontend/semantic/types.py
+++ b/src/frontend/semantic/types.py
@@ -99,6 +99,7 @@ class SetType(VarType):
 
     def __init__(self, element_type: VarType):
         self.element_type = element_type
+        self.attributes = {}
         self.methods = {
             "add": FunctionType(self, [("element", element_type)]),
             "remove": FunctionType(self, [("element", element_type)]),
@@ -132,6 +133,7 @@ class MapType(VarType):
     def __init__(self, key_type: VarType, value_type: VarType):
         self.key_type = key_type
         self.value_type = value_type
+        self.attributes = {}
         self.methods = {
             "get": FunctionType(value_type, [("key", key_type)]),
             "put": FunctionType(self, [("key", key_type), ("value", value_type)]),
@@ -159,7 +161,7 @@ class MapType(VarType):
         return hash(self.__repr__())
 
 
-class CustomType(VarType):
+class CustomTypeIdentifier(VarType):
     """Represents template identifiers
 
     Args:
@@ -170,13 +172,13 @@ class CustomType(VarType):
         self.name = name
 
     def __repr__(self):
-        return f"CustomType({self.name})"
+        return f"CustomTypeIdentifier({self.name})"
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, TemplateType):
             return self.name == other.identifier.name
 
-        return isinstance(other, CustomType) and self.name == other.name
+        return isinstance(other, CustomTypeIdentifier) and self.name == other.name
 
     def __hash__(self) -> int:
         return hash(self.__repr__())
@@ -192,7 +194,7 @@ class TemplateType(VarType):
 
     def __init__(
         self,
-        identifier: CustomType,
+        identifier: CustomTypeIdentifier,
         attributes: Dict[str, VarType],
         methods: Dict[str, FunctionType],
     ):
@@ -204,7 +206,7 @@ class TemplateType(VarType):
         return f"TemplateType({self.identifier}, {self.attributes}, {self.methods})"
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, CustomType):
+        if isinstance(other, CustomTypeIdentifier):
             return self.identifier.name == other.name
 
         if isinstance(other, TemplateType):

--- a/src/frontend/syntax/ast.py
+++ b/src/frontend/syntax/ast.py
@@ -470,7 +470,9 @@ class EntityLiteral(Expression):
         elements (Dict[str, Expression]]): The elements of the entity.
     """
 
-    def __init__(self, template: CustomType, attributes: Dict[str, Expression]) -> None:
+    def __init__(
+        self, template: CustomTypeIdentifier, attributes: Dict[str, Expression]
+    ) -> None:
         self.template = template
         self.attributes = attributes
 

--- a/tests/semantic/test_functions.py
+++ b/tests/semantic/test_functions.py
@@ -343,9 +343,72 @@ def test_invalid_nested_entity_declaration():
     """
     with pytest.raises(
         TypeError,
-        match=r"Type mismatch for attribute `followers`: `ArrayType\(CustomType\(User\)\)` != `PrimitiveType\(INT\)`"
+        match=r"Type mismatch for attribute `followers`: `ArrayType\(CustomTypeIdentifier\(User\)\)` != `PrimitiveType\(INT\)`"
     ):
         analyze_code(code)
+        
+def test_entity_attribute_access():
+    code = """
+        template User = {
+            str name;
+            int age;
+            User[] followers;
+        };
+        
+        entity user = User{
+            name: "James",
+            age: 25,
+            followers: [],
+        };
+        
+        str name = user.name;
+        int age = user.age;
+    """
+    analyze_code(code)
+    
+def test_nested_entity_attribute_access():
+    code = """
+        template User = {
+            str name;
+            int age;
+            User[] followers;
+        };
+        
+        entity user = User{
+            name: "James",
+            age: 25,
+            followers: [
+                User{name: "Bob", age: 30, followers: []},
+                User{name: "Charlie", age: 35, followers: []}
+            ],
+        };
+        
+        str name = user.followers[0].name;
+        int age = user.followers[1].age;
+    """
+    analyze_code(code)
+    
+def test_nested_entity_attribute_assignment():
+    code = """
+        template User = {
+            str name;
+            int age;
+            User[] followers;
+        };
+        
+        entity user = User{
+            name: "James",
+            age: 25,
+            followers: [
+                User{name: "Bob", age: 30, followers: []},
+                User{name: "Charlie", age: 35, followers: []}
+            ],
+        };
+        
+        user.followers[0].name = "Bobby";
+        user.followers[1].age = 40;
+    """
+    analyze_code(code)
 
 
 def test_set_method_call_expression():

--- a/tests/semantic/test_types.py
+++ b/tests/semantic/test_types.py
@@ -267,6 +267,13 @@ def test_empty_array_declaration():
         int[] arr = [];
     """
     analyze_code(code)
+    
+def test_nested_array_assignment():
+    code = """
+        int[][] arr = [[1, 2], [3, 4]];
+        arr[0][0] = 5;
+    """
+    analyze_code(code)
 
 
 def test_invalid_logical_operation():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -903,15 +903,56 @@ def test_entity_declaration():
         [
             VariableDeclaration(
                 "character",
-                CustomType("Person"),
+                CustomTypeIdentifier("Person"),
                 EntityLiteral(
-                    CustomType("Person"),
-                    {
-                        "name": StringLiteral("Alice"),
-                        "age": NumericLiteral(25)
-                    },
+                    CustomTypeIdentifier("Person"),
+                    {"name": StringLiteral("Alice"), "age": NumericLiteral(25)},
                 ),
             )
         ]
     )
     check(code, expected)
+
+
+def test_member_access_expression():
+    code = """
+        int x = foo.bar.baz.qux;
+    """
+    excepted = Program(
+        [
+            VariableDeclaration(
+                "x",
+                PrimitiveType(TokenType.INT),
+                MemberAccessExpression(
+                    MemberAccessExpression(
+                        MemberAccessExpression(Identifier("foo"), Identifier("bar")),
+                        Identifier("baz"),
+                    ),
+                    Identifier("qux"),
+                ),
+            )
+        ]
+    )
+    check(code, excepted)
+    
+def test_property_assignment_expression():
+    code = """
+        foo.bar.baz.qux = 5;
+    """
+    excepted = Program(
+        [
+            ExpressionStatement(
+                AssignmentExpression(
+                    MemberAccessExpression(
+                        MemberAccessExpression(
+                            MemberAccessExpression(Identifier("foo"), Identifier("bar")),
+                            Identifier("baz"),
+                        ),
+                        Identifier("qux"),
+                    ),
+                    NumericLiteral(5),
+                )
+            )
+        ]
+    )
+    check(code, excepted)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -84,7 +84,7 @@ def test_unexpected_keyword():
 
 def test_invalid_function_declaration():
     code = "func add = a, b >> { return a + b; }"
-    check(code, "Expected token TokenType.RETURN_ARROW, but got TokenType.ASSIGN")
+    check(code, "Expected token TokenType.RT_ARROW, but got TokenType.ASSIGN")
 
 
 def test_missing_function_body():


### PR DESCRIPTION
- implements member access and reassignment
- changes `CustomType` to `CustomTypeIdentifier` for clarity
- renames `RETURN_ARROW` token to `RT_ARROW`
- adds custom type lookup at the top level (in the main `analyze` method) to prevent repetition
- removes redundant variable lookup in `analyze_assignment_expression` method